### PR TITLE
fix: get url origin lost https in default hono c.html, since it is SSR

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -18,20 +18,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 检出代码
+      - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: 设置 QEMU
+      - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: 设置 Docker Buildx
+      - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: 登录到 Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: thaddeusjiang
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Define Docker Tag
+        id: prep
+        run: |
+          # github.ref_name maybe `13/merge`
+          DOCKER_TAG=${GITHUB_REF_NAME//\//-}
+          echo "docker_tag=${DOCKER_TAG}" >> $GITHUB_OUTPUT
 
       - name: Build and push image
         uses: docker/build-push-action@v5
@@ -40,7 +47,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.IMAGE_NAME }}:${{ steps.prep.outputs.docker_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import { find } from './apis/find'
 
 const app = new Hono()
 
-export const Home = ({ origin }: { origin: string }) => {
+export const Home = () => {
   return (
     <html>
       <head>
@@ -30,8 +30,8 @@ export const Home = ({ origin }: { origin: string }) => {
         <h2>2. Usage</h2>
 
         <pre>
-          <code>
-            {`curl -X GET "${origin}/api/find?zipcode=1080022"`}
+          <code id="curl-example">
+            {`curl -X GET "/api/find?zipcode=1080022"`}
           </code>
         </pre>
 
@@ -82,14 +82,16 @@ export const Home = ({ origin }: { origin: string }) => {
         </footer>
       </body>
 
+      <script>
+        const url = window.location.origin + `/api/find?zipcode=1080022`;
+        document.getElementById(`curl-example`).textContent = `curl -X GET ` + url;
+      </script>
     </html>
   )
 }
 
 app.get('/', (c) => {
-  const url = new URL(c.req.url);
-
-  return c.html(<Home origin={url.origin} />)
+  return c.html(<Home />)
 })
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The API command displayed on the home page now dynamically reflects your current domain, ensuring accurate instructions across environments.

- **Refactor**
  - The home page component has been streamlined by removing an unnecessary property, leading to a cleaner and more robust user experience.
  
- **Chores**
  - GitHub Actions workflow step names have been updated for clarity and consistency, including the addition of a new step to define a Docker tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->